### PR TITLE
api/v3/*/Getstat - Fix duplicate function names

### DIFF
--- a/api/v3/Activity/Getstat.php
+++ b/api/v3/Activity/Getstat.php
@@ -1,5 +1,5 @@
 <?php
-function civicrm_api3_group_contact_getstat ($params) {
+function civicrm_api3_activity_getstat ($params) {
   $sql="SELECT COUNT(id),DATE(register_date) as register from civicrm_participant group by DATE(register_date)";
   return _civicrm_api3_basic_getsql ($params,$sql);
 }

--- a/api/v3/Participant/Getstat.php
+++ b/api/v3/Participant/Getstat.php
@@ -1,5 +1,5 @@
 <?php
-function civicrm_api3_group_contact_getstat ($params) {
+function civicrm_api3_participant_getstat ($params) {
   $sql="SELECT COUNT(id),DATE(register_date) as register from civicrm_participant group by DATE(register_date)";
   return _civicrm_api3_basic_getsql ($params,$sql);
 }


### PR DESCRIPTION
There are three functions named civicrm_api3_group_contact_getstat(); this smells
like a copy-paste error.
