### PR TITLE
Fix dashlet definitions

### DIFF
--- a/CRM/Civisualize/Dashlet.mgd.php
+++ b/CRM/Civisualize/Dashlet.mgd.php
@@ -1,37 +1,37 @@
 <?php
 
-return array (
-0=>array (
-  'name'=>'dataviz_contact',
-  'entity'=> 'Dashboard',
-  'params'=> array (
-    'version'=>'3',
+return array(
+  array(
     'name'=>'dataviz_contact',
-    'label'=> 'Dataviz of contacts',
-    'url' => CRM_Utils_System::url('civicrm/dataviz/contacts', 'snippet=4'),
-  )
-),
+    'entity'=> 'Dashboard',
+    'params'=> array(
+      'version'=>'3',
+      'name'=>'dataviz_contact',
+      'label'=> 'Dataviz of contacts',
+      'url' => 'civicrm/dataviz/contacts?snippet=4',
+    ),
+  ),
 
-1=>array (
-  'name'=>'dataviz_events',
-  'entity'=> 'Dashboard',
-  'params'=> array (
-    'version'=>'3',
-    'name'=>'dataviz_event',
-    'label'=> 'Dataviz of events',
-    'url' => CRM_Utils_System::url('civicrm/dataviz/events', 'snippet=4'),
-  )
-),
+  array(
+    'name'=>'dataviz_events',
+    'entity'=> 'Dashboard',
+    'params'=> array(
+      'version'=>'3',
+      'name'=>'dataviz_event',
+      'label'=> 'Dataviz of events',
+      'url' => 'civicrm/dataviz/events?snippet=4',
+    ),
+  ),
 
-2=>array (
-  'name'=>'dataviz_contribute',
-  'entity'=> 'Dashboard',
-  'params'=> array (
-    'version'=>'3',
+  array(
     'name'=>'dataviz_contribute',
-    'label'=> 'Dataviz of contributions',
-    'url' => CRM_Utils_System::url('civicrm/dataviz/contribute', 'snippet=4'),
-  )
-)
+    'entity'=> 'Dashboard',
+    'params'=> array(
+      'version'=>'3',
+      'name'=>'dataviz_contribute',
+      'label'=> 'Dataviz of contributions',
+      'url' => 'civicrm/dataviz/contribute?snippet=4',
+    ),
+  ),
 
 );


### PR DESCRIPTION
CiviCRM dashboard dashlets are supposed to store a proto-url which gets passed through `CRM_Utils_System::url` at runtime. This works better with site portability, etc.