### PR TITLE
Update version & release date,

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>Xavier</author>
     <email>xavier@tttp.eu</email>
   </maintainer>
-  <releaseDate>2013-10-05</releaseDate>
-  <version>1.5</version>
+  <releaseDate>2017-03-05</releaseDate>
+  <version>1.6</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.3</ver>


### PR DESCRIPTION
CiviCRM uses the release date. Updating the version & release date & tagging the new release should hopefully cause the most recent release to show as the most recent. 

Although, there might still be a problem if you are tagging v1.6 but version in the info.xml is 1.6