### PR TITLE
Update civix for php 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ xavier made this, sid helped him. You can find us on CiviCRM forum, [@eucampaign
 Changes
 -------
 
+## Version 6.1
+
+- Update civix boilerplate to work with PHP 7.4 without warnings.
+
 ## Version 6.0 brings changes that will probably break your custom visualisations.
 
 It became apparent that version 5's library updates conflicted with CiviCRM's

--- a/civisualize.civix.php
+++ b/civisualize.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Civisualize_ExtensionUtil {
-  const SHORT_NAME = "civisualize";
-  const LONG_NAME = "eu.tttp.civisualize";
-  const CLASS_PREFIX = "CRM_Civisualize";
+  const SHORT_NAME = 'civisualize';
+  const LONG_NAME = 'eu.tttp.civisualize';
+  const CLASS_PREFIX = 'CRM_Civisualize';
 
   /**
    * Translate a string using the extension's domain.
@@ -193,8 +193,9 @@ function _civisualize_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
@@ -220,41 +221,18 @@ function _civisualize_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
  *
- * @return array(string)
+ * @return array
  */
 function _civisualize_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_civisualize_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
@@ -362,7 +340,7 @@ function _civisualize_civix_civicrm_themes(&$themes) {
  * @link http://php.net/glob
  * @param string $pattern
  *
- * @return array, possibly empty
+ * @return array
  */
 function _civisualize_civix_glob($pattern) {
   $result = glob($pattern);
@@ -470,8 +448,6 @@ function _civisualize_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NUL
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _civisualize_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/info.xml
+++ b/info.xml
@@ -9,7 +9,7 @@
     <email>xavier@tttp.eu</email>
   </maintainer>
   <releaseDate>2020-06-15</releaseDate>
-  <version>6.0</version>
+  <version>6.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
Follows on from #114 but does so by re-running `civix generate:module`. This brings php 7.4 compatibility to the civix part.

Also included as separate commit: update to readme and info.xml - let me know if you don't want those.